### PR TITLE
Add requirement to send mail to Eiffel Community maillist

### DIFF
--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -88,7 +88,7 @@ a pull request to community repository, updating the stage of their project for 
 is concluded upon acceptance of the pull request.
 
 Upon completion of the project lifecycle process, TC Chair sends an email to [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community)
-in order to announce the changes to project lifecycle stage to broader community for increased visibility.
+in order to announce the changes to project lifecycle stage to the broader community for increased visibility.
 
 ### Stage: Sandbox
 

--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -65,7 +65,7 @@ repository and include an entry for their project. Project creation is concluded
 request.
 
 Upon completion of the project creation process, TC Chair sends an email to [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community)
-in order to announce the creation of the project to broader community for increased visibility.
+in order to announce the creation of the project to the broader community for increased visibility.
 
 ## Project Lifecycle Stages
 

--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -38,12 +38,19 @@ their ability.
 - names of initial maintainers
 - infrastructure needs such as Git repositories
 
-Regarding project naming conventions, the Eiffel Community enforces no name convention but meaningful descriptive 
-names are encouraged. 
+In addition to formally proposing the project on GitHub, community members proposing the new project are expected
+to announce the project proposal on [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community) by
+sending an email in order to increase the visibility. The email should contain same information as the proposal
+itself.
+
+Regarding project naming conventions, the Eiffel Community enforces no name convention but meaningful descriptive
+names are encouraged.
 
 Projects that are already hosted within Eiffel Community but willing to move to a different stage are also
 expected to follow same process as project creation by formally submitting their request on GitHub Eiffel
-Community repository by creating an issue.
+Community repository by creating an issue. Similar to proposing new projects, proposals to move projects
+to different lifecycle stage should also be announced on [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community)
+by sending an email for increased visibility.
 
 ### Project Acceptance Process
 
@@ -56,6 +63,9 @@ Simple majority of Eiffel Community Maintainers is required for a project to be 
 Project maintainers are expected to update [PROJECTS.md](./PROJECTS.md) by sending a pull request to community
 repository and include an entry for their project. Project creation is concluded upon acceptance of the pull
 request.
+
+Upon completion of the project creation process, TC Chair sends an email to [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community)
+in order to announce the creation of the project to broader community for increased visibility.
 
 ## Project Lifecycle Stages
 
@@ -76,6 +86,9 @@ easier for potential users to see where the project is in its lifecycle. In addi
 stage listed on the project repositories, project maintainers are expected to update [PROJECTS.md](./PROJECTS.md) via
 a pull request to community repository, updating the stage of their project for broader visibility. Project review
 is concluded upon acceptance of the pull request.
+
+Upon completion of the project lifecycle process, TC Chair sends an email to [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community)
+in order to announce the changes to project lifecycle stage to broader community for increased visibility.
 
 ### Stage: Sandbox
 

--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -47,7 +47,7 @@ Regarding project naming conventions, the Eiffel Community enforces no name conv
 names are encouraged.
 
 Projects that are already hosted within Eiffel Community but willing to move to a different stage are also
-expected to follow same process as project creation by formally submitting their request on GitHub Eiffel
+expected to follow same process as project creation by formally submitting their request on Eiffel
 Community repository by creating an issue. Similar to proposing new projects, proposals to move projects
 to different lifecycle stage should also be announced on [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community)
 by sending an email for increased visibility.

--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -40,7 +40,7 @@ their ability.
 
 In addition to formally proposing the project on GitHub, community members proposing the new project are expected
 to announce the project proposal on [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community) by
-sending an email in order to increase the visibility. The email should contain same information as the proposal
+sending an email in order to increase the visibility. The email should contain the same information as the proposal
 itself.
 
 Regarding project naming conventions, the Eiffel Community enforces no name convention but meaningful descriptive


### PR DESCRIPTION
New project proposals and proposals to move projects to different
lifecycle stages should be announced on Eiffel Community maillist
in order to increase the visibility.

Once the project creation or project lifecycle process is concluded,
TC chair sends an email to Eiffel Community maillist and announce
the new project or the lifecycle stage to broader Eiffel Community.

### Applicable Issues

Closes AP from [TC meeting](https://hackmd.io/SCImga0nS1qSh3QvsEOAVQ?view#Action-Items).

### Description of the Change

Project proposals and lifecycle stage changes are handled via GitHub issues in Eiffel Community community repository, which is not monitored by broader community.
In order to increase the visibility, transparency and community participation, it is important to announce this type of changes to the community on Eiffel Community Maillist.

This commit updates project lifecycle document to require such mails to be sent to the maillist.

### Alternate Designs

N/A

### Benefits

Increased visibility, transparency, and community participation.

### Possible Drawbacks

N/A

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fatih Degirmenci fatih.degirmenci@est.tech
