### PR TITLE
Added link to mission-and-vision.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The contents of this repository are licensed under the [Apache License 2.0](./LI
 # About Eiffel
 This repository forms part of the Eiffel Community. Eiffel is a protocol for technology agnostic machine-to-machine communication in continuous integration and delivery pipelines, aimed at securing scalability, flexibility and traceability. Eiffel is based on the concept of decentralized real time messaging, both to drive the continuous integration and delivery system and to document it.
 
-Visit [Eiffel Community](https://eiffel-community.github.io) to get started and get involved.
+Visit [Eiffel Community](https://eiffel-community.github.io) to get started and get involved and read about our [Vision and Mission](https://eiffel-community.github.io/vision-and-mission.html).
 
 # Contact
 New to the community? Got a lot of questions but don't know where to post them? Or just want to catch up on what's happening?

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The contents of this repository are licensed under the [Apache License 2.0](./LI
 # About Eiffel
 This repository forms part of the Eiffel Community. Eiffel is a protocol for technology agnostic machine-to-machine communication in continuous integration and delivery pipelines, aimed at securing scalability, flexibility and traceability. Eiffel is based on the concept of decentralized real time messaging, both to drive the continuous integration and delivery system and to document it.
 
-Visit [Eiffel Community](https://eiffel-community.github.io) to get started and get involved and read about our [Vision and Mission](https://eiffel-community.github.io/vision-and-mission.html).
+Visit [Eiffel Community](https://eiffel-community.github.io) to get started and get involved and read about our [Mission and Vision](https://eiffel-community.github.io/mission-and-vision.html).
 
 # Contact
 New to the community? Got a lot of questions but don't know where to post them? Or just want to catch up on what's happening?

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Eiffel Community
 This repository contains common Eiffel resources and information that does not belong to specific Eiffel repositories. General issues that concerns all repositories can be posted and discussed in this repository as well.
 
-The https://github.com/eiffel-community/.github/ repository contains all community health files (that is: code of conduct, contributing guidelines, issue and pull request templates)
+The https://github.com/eiffel-community/.github/ repository contains all community health files (that is: code of conduct, contributing guidelines, issue and pull request templates).
 
 # Code of Conduct and Contributing
 To get involved, please see [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/eiffel-community/.github/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
### Applicable Issues
#10 
It depends on https://github.com/eiffel-community/eiffel-community.github.io/pull/17

### Description of the Change
This change adds a link from README.md to the mission-and-vision.html page on the github.io site.

### Alternate Designs
You could state the mission and vision directly in some .md file, but putting it on the github.io page provides greater visibility I think.

### Benefits
It solves #10

### Possible Drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
Daniel Ståhl daniel.stahl@ericsson.com