### PR TITLE
Document security officers, the role, and its responsibilities

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -89,7 +89,7 @@ The term for Security Officers is **one year**.
 Responsibilities of Security Officers are
 
 * Be the main contact with regards to community vulnerability and security issues including for the issues reported by users or discovered by the community members
-* Be a member to private community mail list eiffel-community-security@googlegroups.com and monitor it actively
+* Be a member of private community mail list eiffel-community-security@googlegroups.com and monitor it actively
 * Ensure the reported issues are acknowledged, analysed, addressed, fixed, released, and responded accordingly
 * Ensure the public disclosure of the issue and required fixes are done in a timely manner
 * Ensure community vulnerability and security reporting and response process is followed by the community

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -82,7 +82,24 @@ Eiffel Community Election Officers are the individuals listed below:
 
 ### Security Officers
 
-TBD
+Eiffel Community Security Officers are the community members who are appointed by Eiffel Technical Committee to oversee [Eiffel Community Vulnerability and Security Reporting and Response process](./SECURITY.md).
+
+The term for Security Officers is **one year**.
+
+Responsibilities of Security Officers are
+
+* Be the main contact with regards to community vulnerability and security issues including for the issues reported by users or discovered by the community members
+* Be a member to private community mail list eiffel-community-security@googlegroups.com and monitor it actively
+* Ensure the reported issues are acknowledged, analysed, addressed, fixed, released, and responded accordingly
+* Ensure the public disclosure of the issue and required fixes are done in a timely manner
+* Ensure community vulnerability and security reporting and response process is followed by the community
+
+Eiffel Community is served by **2** Security Officers.
+
+Eiffel Community Security Officers are the individuals listed below:
+
+* Fredrik Fristedt, Axis Communications
+* Kristofer Hallén, Ericsson
 
 ## Technical Committee
 


### PR DESCRIPTION
### Applicable Issues

fixes #91 

### Description of the Change

Eiffel Community established and documented security/vulnerability reporting and response process.
This process is overseen by Eiffel Community Security Officers who are appointed by Eiffel Technical Committee.

This PR documents the role, responsibilities, and term of the Security officers together with the appointed community members in governance.

### Alternate Designs

N/A

### Benefits

Increased transparency and communication.

### Possible Drawbacks

N/A

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fatih Degirmenci fatih.degirmenci@est.tech
