### PR TITLE
Add "New project" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,22 @@
+---
+name: General issue
+about: Bug reports, feature requests, etc.
+---
+<!--
+Filling out the template is required. Any issue that does not include enough information may be closed at the maintainers' discretion.
+-->
+
+### Description
+<!-- Describe the proposed or requested change, and explain the type of change. Is it a change to the protocol, to the documentation, or something else? -->
+
+### Motivation
+<!-- Why would you like to see this change? -->
+
+### Exemplification
+<!-- Can you think of a concrete example illustrating the impact and value of the change? -->
+
+### Benefits
+<!-- What would the benefits of introducing this change be? -->
+
+### Possible Drawbacks
+<!-- What are the possible side-effects or negative impacts of the change, and why are they outweighed by the benefits? -->

--- a/.github/ISSUE_TEMPLATE/new_project.md
+++ b/.github/ISSUE_TEMPLATE/new_project.md
@@ -1,0 +1,26 @@
+---
+name: New project
+about: A request to start a new project (repository)
+title: New project "(insert name here)"
+labels: project-lifecycle
+---
+<!--
+Filling out the template is required. Any issue that does not include enough information may be closed at the maintainers' discretion.
+
+See https://github.com/eiffel-community/community/blob/master/PROJECT_LIFECYCLE.md for a detailed description of the process.
+-->
+
+### Name
+<!-- The name of the project. -->
+
+### Description
+<!-- What would it do and why would that be valuable? Please provide relevant background. -->
+
+### Project license
+<!-- Most Eiffel Community projects are licensed under Apache License 2.0 but other license choices are possible. -->
+
+### Names of initial maintainers
+<!-- Prefer listing at least two maintainers since PRs are expected to be reviewed by two people. -->
+
+### Infrastructure needs
+<!-- Most projects need at least one Git repository under https://github.com/eiffel-community. -->

--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -1,0 +1,55 @@
+---
+name: General pull request
+about: Bug reports, feature requests, etc.
+---
+<!--
+Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
+-->
+
+### Applicable Issues
+<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
+
+### Description of the Change
+<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
+
+### Alternate Designs
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Benefits
+<!-- What benefits will be realized by the change? -->
+
+### Possible Drawbacks
+<!-- What are the possible side-effects or negative impacts of the change? -->
+
+### Sign-off
+<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
+<!-- The certificate is copied from https://developercertificate.org/ -->
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+Signed-off-by: <!-- <Your full name> <your-email@example.org> -->


### PR DESCRIPTION
### Applicable Issues
Fixes #101

### Description of the Change
We copy the issue and PR templates from the .github repo in order to add a second issue template. This is unfortunately necessary since issue and PR templates are only inherited from the .github repo when the repo in question lacks templates entirely. See https://github.community/t/default-community-files-ignores-issue-templates/2802/7.

The new issue template will the "New issue" button (i.e. a visit to https://github.com/eiffel-community/community/issues/new/choose) to result in a menu where you can choose between creating a general issue and creating a request to create a new project. The section headings for the latter have been taken from PROJECT_LIFECYCLE.md.

### Alternate Designs
None.

### Benefits
Easier for people to file project creation requests. Reduced risk of people filing incomplete such requests.

### Possible Drawbacks
An extra choice to make after you've clicked "New issue". The .github directory also needs to be kept in sync with the same directory in https://github.com/eiffel-community/.github.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
