### PR TITLE
add-new-repository.md: Use repo template as a template

### DIFF
--- a/howtos/add-new-repository.md
+++ b/howtos/add-new-repository.md
@@ -11,7 +11,6 @@ Want to extend the Eiffel community with a new repository?
 1. Read through the [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/eiffel-community/.github/blob/master/CONTRIBUTING.md) for Eiffel Community and understand the content.
 
 1. Decide on a name for the repository. The Eiffel Community enforces no name convention but meaningful descriptive names are encouraged.
-1. Create the repository in the [eiffel-community organization](https://github.com/organizations/eiffel-community/repositories/new). The repository should be public. Do NOT choose "import repository". The reason for this is to maintain a clean git history.
-1. Copy the content of [eiffel-repository-template](https://github.com/eiffel-community/eiffel-repository-template).
+1. Create the repository in the [eiffel-community organization](https://github.com/organizations/eiffel-community) by visiting the [eiffel-repository-template](https://github.com/eiffel-community/eiffel-repository-template) repository and clicking the _Use this template_ button found above the file list. The new repository should be public and the _Include all branches_ option should _not_ be checked. See the [GitHub documentation](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) for details.
 1. Follow the checklist in the repository template to update your repository structure.
 1. (Optional) Spread the word about the new repository, on e.g. Slack!


### PR DESCRIPTION
### Applicable Issues
Fixes https://github.com/eiffel-community/eiffel-repository-template/issues/7

### Description of the Change
We have a template repository, eiffel-repository-template, but previously it hasn't been marked as a template repo in its settings,hence the "Use this template" button has been unavailable and copying of the repo contents has been entirely manual. This setting has now been enabled and the repo creation documentation should be updated to reflect this.

### Alternate Designs
None.

### Benefits
Easier repository creation.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
