### PR TITLE
Add new document for the 2022 TC meetings

### DIFF
--- a/meetings/MEETINGS_TC_2022.md
+++ b/meetings/MEETINGS_TC_2022.md
@@ -1,0 +1,21 @@
+###### tags: `Technical Committee`
+
+# Technical Committee Meetings 2022
+
+[![HackMD documents](https://hackmd.io/badge.svg)](https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg)
+
+## Quick links
+
+* [Logistics](#logistics)
+* [Agenda and Notes](#agenda-and-notes)
+
+## Logistics
+
+* **When:** 13:00 - 14:00 CET, every even week on Thursdays
+* **Where:** [Microsoft Teams Meeting](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDljZGI1ZDEtOGRhYS00NzlmLTlkZTgtNTM4OGMwNmU3ZTVh%40thread.v2/0?context=%7b%22Tid%22%3a%22d2585e63-66b9-44b6-a76e-4f4b217d97fd%22%2c%22Oid%22%3a%22b5142d0f-6dad-4704-99f5-29b74621c34a%22%7d)
+* **Meeting Agenda and Minutes:** https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg
+* **Community Repo:** https://github.com/eiffel-community/community
+
+## Agenda and Notes
+
+Please do not update the meeting agenda and notes directly on GitHub and instead use the document on [HackMD.io](https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg) in order to prevent notes getting out of sync.

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -4,9 +4,10 @@ This directory contains minutes from various Eiffel Community meetings.
 
 Current:
 
-* [Technical Committee Meetings 2021](MEETINGS_TC_2021.md)
+* [Technical Committee Meetings 2022](MEETINGS_TC_2022.md)
 * [Eiffel Community Monthly Meetings](https://hackmd.io/mew2t6NqSBe7aRkzQkWNqg)
 
 Archive:
 
+* [Technical Committee Meetings 2021](MEETINGS_TC_2021.md)
 * [Bootstrap Technical Committee Meeting Archive](MEETINGS_BTC.md)


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
A new year requires a new HackMD document for the minutes of the TC meetings. This needs to be added to the meetings directory.

### Alternate Designs
None.

### Benefits
Next year's TC meetings published like previous years'.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
