### PR TITLE
GOVERNANCE.md: Remove David Westberg from TC member table

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -236,7 +236,6 @@ Members of the Technical Committee are the individuals listed below:
 
 Full Name         | Company   | GitHub                                                       | Elected On  | Until
 ------------------|:---------:|--------------------------------------------------------------|-------------|-----------
-David Westberg    | Volvo     | [t031276](https://github.com/t031276)                        | April 2021  | April 2022
 Emil Bäckmark     | Ericsson  | [e-backmark-ericsson](https://github.com/e-backmark-ericsson)| April 2021  | April 2022
 Magnus Bäck       | Axis      | [magnusbaeck](https://github.com/magnusbaeck)                | April 2021  | April 2022
 Mattias Linnèr    | Ericsson  | [m-linner-ericsson](https://github.com/m-linner-ericsson)    | April 2021  | April 2022


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
David has chosen to leave the technical committee so he should be removed from the table of TC members.

### Alternate Designs
Considered leaving breadcrumbs to indicate that he was duly elected but chose to leave, but figured that we have the git history for that. The TC membership table should reflect the current reality.

### Benefits
Governance document reflects reality.

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
