### PR TITLE
GOVERNANCE.md: Add TC member's email addresses

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -232,14 +232,14 @@ If the number of candidates is one and their candidacy is unchallenged, Election
 Members of the Technical Committee are appointed via community elections. Project maintainers are eligible to run as candidates for the Technical Committee in elections.
 Maintainers and contributors are eligible to vote in elections.
 
-Members of the Technical Committee are the individuals listed below:
+Members of the Technical Committee are the individuals listed below. You can reach all current members with the [eiffel-tc@googlegroups.com](mailto:eiffel-tc@googlegroups.com) mailing list.
 
-Full Name         | Company   | GitHub                                                       | Elected On  | Until
-------------------|:---------:|--------------------------------------------------------------|-------------|-----------
-Emil Bäckmark     | Ericsson  | [e-backmark-ericsson](https://github.com/e-backmark-ericsson)| April 2021  | April 2022
-Magnus Bäck       | Axis      | [magnusbaeck](https://github.com/magnusbaeck)                | April 2021  | April 2022
-Mattias Linnèr    | Ericsson  | [m-linner-ericsson](https://github.com/m-linner-ericsson)    | April 2021  | April 2022
-Tobias Persson    | Axis      | [t-persson](https://github.com/t-persson)                    | April 2021  | April 2022
+Full Name         | Company   | GitHub                                                        | Email Address                                                     | Elected On  | Until
+------------------|:---------:|-------------------------------------------------------------- |-------------------------------------------------------------------|-------------|-----------
+Emil Bäckmark     | Ericsson  | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | [emil.backmark@ericsson.com](mailto:emil.backmark@ericsson.com)   | April 2021  | April 2022
+Magnus Bäck       | Axis      | [magnusbaeck](https://github.com/magnusbaeck)                 | [magnus.back@axis.com](mailto:magnus.back@axis.com)               | April 2021  | April 2022
+Mattias Linnèr    | Ericsson  | [m-linner-ericsson](https://github.com/m-linner-ericsson)     | [mattias.linner@ericsson.com](mailto:mattias.linner@ericsson.com) | April 2021  | April 2022
+Tobias Persson    | Axis      | [t-persson](https://github.com/t-persson)                     | [tobias.persson@axis.com](mailto:tobias.persson@axis.com)         | April 2021  | April 2022
 
 The technical committee members will strive to
 
@@ -259,10 +259,10 @@ The goal of this position is servant leadership for the Eiffel Community, projec
 
 Current Technical Committee chairs are:
 
-Full Name         | Company   | GitHub                                                       | Elected On  | Until
-------------------|:---------:|--------------------------------------------------------------|-------------|-----------
-Emil Bäckmark     | Ericsson  | [e-backmark-ericsson](https://github.com/e-backmark-ericsson)| May 2021  | April 2022
-Magnus Bäck       | Axis      | [magnusbaeck](https://github.com/magnusbaeck)                | May 2021  | April 2022
+Full Name         | Company   | GitHub                                                       | Email Address                                                   | Elected On  | Until
+------------------|:---------:|--------------------------------------------------------------|-----------------------------------------------------------------|-------------|-----------
+Emil Bäckmark     | Ericsson  | [e-backmark-ericsson](https://github.com/e-backmark-ericsson)| [emil.backmark@ericsson.com](mailto:emil.backmark@ericsson.com) | May 2021    | April 2022
+Magnus Bäck       | Axis      | [magnusbaeck](https://github.com/magnusbaeck)                | [magnus.back@axis.com](mailto:magnus.back@axis.com)             | May 2021    | April 2022
 
 The chairs MUST ensure that
 


### PR DESCRIPTION
### Applicable Issues
N/A; following decision made at the [2021-12-02 TC meeting](https://github.com/eiffel-community/community/blob/master/meetings/MEETINGS_TC_2021.md#december-02-2021).

### Description of the Change
The TC decided that it makes sense to have the members' email addresses visible along with their GitHub handles. Also included the TC mailing list address.

### Alternate Designs
None.

### Benefits
Easier to get in contact with the TC.

### Possible Drawbacks
Might expose TC members to more spam.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
