### PR TITLE
Updated Eiffel Commumity security policy reference

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -83,7 +83,7 @@ Eiffel Community Election Officers are the individuals listed below:
 
 ### Security Officers
 
-Eiffel Community Security Officers are the community members who are appointed by Eiffel Technical Committee to oversee [Eiffel Community Vulnerability and Security Reporting and Response process](./SECURITY.md).
+Eiffel Community Security Officers are the community members who are appointed by Eiffel Technical Committee to oversee [Eiffel Community Vulnerability and Security Policy](https://github.com/eiffel-community/community/security/policy).
 
 The term for Security Officers is **one year**.
 


### PR DESCRIPTION
### Description of the Change
Previous link was broken, probably due to some restructuring of information. Link now correctly points to the Security policy page.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrikfristedt@gmail.com>>
