### PR TITLE
Update security officer description

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -89,11 +89,12 @@ The term for Security Officers is **one year**.
 
 Responsibilities of Security Officers are
 
-* Be the main contact with regards to community vulnerability and security issues including for the issues reported by users or discovered by the community members
-* Be a member of private community mail list eiffel-community-security@googlegroups.com and monitor it actively
-* Ensure the reported issues are acknowledged, analysed, addressed, fixed, released, and responded accordingly
+* Be the main contact with regards to community vulnerability and security issues including for the issues reported by users or discovered by the community members. The security officers do not take responsibility for security issues in individual repositories.
+* Be a member of private community mail list eiffel-community-security@googlegroups.com and monitor it actively.
+* Monitor the community [security advisories](https://github.com/eiffel-community/community/security/advisories). 
+* Inform repository owners of reported issues. Acknowledging, analysing, fixing, and releasing is a responsibility for repository maintainers.
 * Ensure the public disclosure of the issue and required fixes are done in a timely manner
-* Ensure community vulnerability and security reporting and response process is followed by the community
+* Ensure community vulnerability and security reporting and response process is followed by the community. 
 
 Eiffel Community is served by **2** Security Officers.
 


### PR DESCRIPTION
### Applicable Issues
[141](https://github.com/eiffel-community/community/issues/141)

### Description of the Change
Update security officer description to better show that security officers can inform and support repository maintainers but security officers do not have a responsibility to fix security issues in the repositories.

### Alternate Designs
Keep as is, but this gives the impression of a responsibility that can't be fulfilled today.

### Benefits
Well defined role description

### Possible Drawbacks
N/A

### Sign-off


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Kristofer Hallén  kristofer.hallen@ericsson.com
