### PR TITLE
GOVERNANCE.md: Remove Azeem from TC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -237,7 +237,6 @@ Members of the Technical Committee are the individuals listed below. You can rea
 
 Full Name         | Company              | GitHub                                                        | Email Address                                                     | Elected On  | Until
 ------------------|:--------------------:|-------------------------------------------------------------- |-------------------------------------------------------------------|-------------|-----------
-Azeem Ahmad       | Volvo Group          | [azeem59](https://github.com/azeem59)                         | [azeem59@gmail.com](mailto:azeem59@gmail.com)                     | May 2022    | May 2023
 Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | [emil.backmark@ericsson.com](mailto:emil.backmark@ericsson.com)   | May 2022    | May 2023
 Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | [magnus.back@axis.com](mailto:magnus.back@axis.com)               | May 2022    | May 2023
 Mattias Linnèr    | Ericsson             | [m-linner-ericsson](https://github.com/m-linner-ericsson)     | [mattias.linner@ericsson.com](mailto:mattias.linner@ericsson.com) | May 2022    | May 2023


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
Since Azeem nowadays is an Ericsson employee (from which we already have two TC representatives) he'll cede his spot in the TC.

### Alternate Designs
None.

### Benefits
TC membership list reflects reality.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
