### PR TITLE
Add new document for the 2023 TC meetings

### DIFF
--- a/meetings/MEETINGS_TC_2023.md
+++ b/meetings/MEETINGS_TC_2023.md
@@ -1,0 +1,74 @@
+###### tags: `Technical Committee`
+
+# Technical Committee Meetings 2023
+
+[![HackMD documents](https://hackmd.io/badge.svg)](https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg)
+
+## Quick links
+
+* [Logistics](#logistics)
+* [Agenda and Notes](#agenda-and-notes)
+    * [2023-01-12 Meeting](#January-12-2023)
+
+## Logistics
+
+* **When:** 13:00 - 14:00 CET, every even week on Thursdays
+* **Where:** [Microsoft Teams Meeting](https://teams.microsoft.com/l/meetup-join/19%3ameeting_OTc1NDIzNTUtYzJiMy00OThiLTkwZDUtYTdkODVhOGNjYzI3%40thread.v2/0?context=%7b%22Tid%22%3a%2292e84ceb-fbfd-47ab-be52-080c6b87953f%22%2c%22Oid%22%3a%2249725723-aa8c-4dcf-b9d0-b974e8a25702%22%7d)
+* **Meeting Agenda and Minutes:** https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg
+* **Community Repo:** https://github.com/eiffel-community/community
+
+## Agenda and Notes
+
+Please do not update the meeting agenda and notes directly on GitHub and instead use the document on [HackMD.io](https://hackmd.io/sL9z7MGwSCOGSCXeY27mFg) in order to prevent notes getting out of sync.
+
+### Next
+
+* June 2023: Elect security officers - https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#security-officers
+    * This should be covered by a post-election checklist.
+
+### January 11, 2023
+
+#### Participants
+
+* TC Attendees
+    * Emil Bäckmark, present / not present
+    * Magnus Bäck, present / not present
+    * Mattias Linnér, present / not present
+    * Tobias Persson, present / not present
+
+#### Agenda and Notes
+
+* Rollcall, All
+* Approval of Previous Minutes, All
+* Agenda Bashing, All
+* Action Item Review, All
+* Updates from CDF sig-events, Emil & Mattias
+* Reasoning about events as being in the traceability dimension or the activity dimension; should we document this and how?
+* [Common branching strategy?](https://github.com/eiffel-community/community/issues/150)
+* PRs and issues
+
+#### Action Items
+* Tobias: Fatih to get Tobias and Mattias in touch with Nordix for Kubernetes cluster installation
+    * [Fatih] Still pending unfortunately. Will come back to this as soon as I get some time.
+    * Update 2021-08-12: Question sent to Fatih but no reply yet.
+    * Update 2021-09-09: Future communication to be done directly with Nordix via their mailing list.
+    * Update 2021-10-07: Cluster running, access control situation unclear.
+    * Update 2021-10-21: Tobias and Mattias have SSH access to one of the hosts but we don't appear to have k8s access.
+    * Update 2022-01-27: Probably simple to fix, Tobias to ping Robert at Nordix.
+    * Update 2022-02-17: Tobias has pinged Robert. Waiting for response.
+    * Update 2022-09-29: Robert has promised to fix the problem this month.
+    * Update 2022-11-03: Emil and Mattias will talk to Nordix.
+    * Update 2022-11-17: New Nordix contact established.
+    * Update 2022-12-01: We now have access to a k8s cluster via a jumphost. No inbound access from the internet though.
+* TC: Add all TC members to all existing Eiffel Google groups
+    * **Update 2022-12-12:** With what role? See also https://github.com/eiffel-community/community/pull/155
+* TC: Look into proposal made in the maintainer role presentation from the 2021 summit.
+* Magnus: Collect feedback from the Python Podcast.\_\_init\_\_ interview to see if there are concrete steps we can take to improve how things are presented or explained.
+* Magnus: Go through current action list and suggest which should be migrated to issues in the community repo.
+* Magnus: Announce podcast episode on LinkedIn.
+* TC: Investigate if we can obtain legal assistance from Software Center.
+* Emil: Send invite for separate meeting to discuss event linking vs. CDevents.
+    * **Update 2022-12-12:** https://www.when2meet.com/?17987352-Gk4R3
+* ~~Emil: Update Jan 19 community meeting invite to state the topic. On the Jan 12 TC meeting we'll decide which issues to actually talk about.~~
+* ~~Magnus: Follow [checklist](https://github.com/eiffel-community/community/blob/master/howtos/introduction-of-a-new-tc-member.md) to revert authorities for Azeem.~~
+* Emil: Create a project board for the protocol to handle priorities for the protocol issues. Readable by all in the community and writeable by protocol maintainers.

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -4,10 +4,12 @@ This directory contains minutes from various Eiffel Community meetings.
 
 Current:
 
-* [Technical Committee Meetings 2022](MEETINGS_TC_2022.md)
+* [Technical Committee Meetings 2023](MEETINGS_TC_2023.md)
 * [Eiffel Community Monthly Meetings](https://hackmd.io/mew2t6NqSBe7aRkzQkWNqg)
 
 Archive:
 
+* [Technical Committee Meetings 2022 2H](MEETINGS_TC_2022_2H.md)
+* [Technical Committee Meetings 2022 1H](MEETINGS_TC_2022_1H.md)
 * [Technical Committee Meetings 2021](MEETINGS_TC_2021.md)
 * [Bootstrap Technical Committee Meeting Archive](MEETINGS_BTC.md)


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
The new MoM document has been prepopulated with the preliminary agenda of this year's first TC meeting on Jan 11.

Last year we reached the size limit of HackMD documents and had to split the document in two. This isn't being done upfront for 2023 since we've changed how actions are tracked (we now primarily use GitHub issues) so it's unlikely we'll hit the limit again.

### Alternate Designs
None.

### Benefits
Syncing of the HackMD document for the TC meeting MoM will continue to work.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
