### PR TITLE
GOVERNANCE.md: Add end date for election and security officers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -76,7 +76,7 @@ Responsibilities of Election Officers are
 
 Eiffel Community is served by **2** election officers.
 
-Eiffel Community Election Officers are the individuals listed below:
+Eiffel Community Election Officers are the individuals listed below, appointed for a term ending January 27, 2023:
 
 * Daniel Ståhl, Ericsson
 * Fatih Degirmenci, Ericsson Software Technology
@@ -98,7 +98,7 @@ Responsibilities of Security Officers are
 
 Eiffel Community is served by **2** Security Officers.
 
-Eiffel Community Security Officers are the individuals listed below:
+Eiffel Community Security Officers are the individuals listed below, appointed for a term ending May 31, 2023:
 
 * Fredrik Fristedt, Axis Communications
 * Kristofer Hallén, Ericsson


### PR DESCRIPTION

### Applicable Issues
Fixes #137 

### Description of the Change
Specifying the end-of-term dates for the current election and security officers. The term for the security officers was decided at the 2022-08-25 TC meeting. The appointment of the election officers wasn't clearly documented so the 2022-01-27 TC meeting where Fatih clearly acted as an election officer was taken as the date of appointment.

### Alternate Designs
None.

### Benefits
It's clearly useful for elected and appointed officials to have their terms stated somewhere.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
