### PR TITLE
Add presentations/README.md

### DIFF
--- a/presentations/README.md
+++ b/presentations/README.md
@@ -1,0 +1,9 @@
+# Presentations
+
+This directory contains the slides for various Eiffel-related
+presentations. Each summit has its own subdirectory and the root
+directory mainly contains slides from workshops and community
+meetings.
+
+The [Eiffel Community YouTube channel](https://www.youtube.com/@EiffelCommunity)
+has recordings of some of the presentations.


### PR DESCRIPTION
### Applicable Issues
Fixes #197

### Description of the Change
Adds a README files to the [presentations directory](https://github.com/eiffel-community/community/tree/master/presentations) to make it more clear what's stored there, and to give an opportunity to link to the YouTube channel.

### Alternate Designs
None.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
