### PR TITLE
GOVERNANCE.md: Remove email addresses

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -236,11 +236,11 @@ Maintainers and contributors are eligible to vote in elections.
 
 Members of the Technical Committee are the individuals listed below. You can reach all current members with the [eiffel-tc@googlegroups.com](mailto:eiffel-tc@googlegroups.com) mailing list.
 
-Full Name         | Company              | GitHub                                                        | Email Address                                                     | Elected On | Until
-------------------|:--------------------:|-------------------------------------------------------------- |-------------------------------------------------------------------|------------|-----------
-Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | [emil.backmark@ericsson.com](mailto:emil.backmark@ericsson.com)   | May 2024   | May 2025
-Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | [magnus.back@axis.com](mailto:magnus.back@axis.com)               | May 2024   | May 2025
-Mattias Linnér    | Ericsson             | [m-linner-ericsson](https://github.com/m-linner-ericsson)     | [mattias.linner@ericsson.com](mailto:mattias.linner@ericsson.com) | May 2024   | May 2025
+Full Name         | Company              | GitHub                                                        | Elected On | Until
+------------------|:--------------------:|---------------------------------------------------------------|------------|-----------
+Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | May 2024   | May 2025
+Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | May 2024   | May 2025
+Mattias Linnér    | Ericsson             | [m-linner-ericsson](https://github.com/m-linner-ericsson)     | May 2024   | May 2025
 
 The technical committee members will strive to
 
@@ -260,10 +260,10 @@ The goal of this position is servant leadership for the Eiffel Community, projec
 
 Current Technical Committee chairs are:
 
-Full Name         | Company              | GitHub                                                       | Email Address                                                   | Elected On | Until
-------------------|:--------------------:|--------------------------------------------------------------|-----------------------------------------------------------------|------------|-----------
-Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson)| [emil.backmark@ericsson.com](mailto:emil.backmark@ericsson.com) | May 2024   | May 2025
-Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                | [magnus.back@axis.com](mailto:magnus.back@axis.com)             | May 2024   | May 2025
+Full Name         | Company              | GitHub                                                        | Elected On | Until
+------------------|:--------------------:|---------------------------------------------------------------|------------|-----------
+Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | May 2024   | May 2025
+Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | May 2024   | May 2025
 
 The chairs MUST ensure that
 


### PR DESCRIPTION
### Applicable Issues
Fixes #193

### Description of the Change
Removing the email addresses makes it slightly harder to harvest them for nefarious purposes. We still include people's GitHub profile where people can choose to include their email address, to the extent they're needed given other possible avenues of contact.

### Alternate Designs
None.

### Possible Drawbacks
Could make it slightly harder to reach people.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
