### PR TITLE
GOVERNANCE.md: Limit TC eligibles to maintainers of non-archived repos

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -146,7 +146,7 @@ Information related to conducted and ongoing elections are kept in [ELECTIONS.md
 
 #### Election Rules
 
-1. Anyone who is a maintainer of one or more projects hosted in the [Eiffel Community GitHub organization](https://github.com/eiffel-community) is eligible to run for a seat in the Eiffel Technical Committee or nominate another maintainer as a candidate. The list of eligible candidates will be sent for review to the Eiffel Community prior to the start of the nomination phase. Anyone in the Eiffel Community can request an exemption to add/remove a candidate in that list by replying to the review.
+1. Anyone who is a maintainer of one or more non-archived projects hosted in the [Eiffel Community GitHub organization](https://github.com/eiffel-community) is eligible to run for a seat in the Eiffel Technical Committee or nominate another maintainer as a candidate. The list of eligible candidates will be sent for review to the Eiffel Community prior to the start of the nomination phase. Anyone in the Eiffel Community can request an exemption to add/remove a candidate in that list by replying to the review.
 1. Anyone who is a member of the [Eiffel Community Maillist](https://groups.google.com/g/eiffel-community) is eligible to vote in Technical Committee Elections.
 1. Community elections are overseen by [Election Officers](#Election-Officers).
 1. The members of Technical Committee are elected using [Ranked Voting](https://en.wikipedia.org/wiki/Ranked_voting).


### PR DESCRIPTION
### Applicable Issues
Fixes #212

### Description of the Change
As discussed at the [2024-03-27 TC meeting](https://github.com/eiffel-community/community/blob/master/meetings/MEETINGS_TC_2024.md#March-27-2024), only maintainers of non-archived projects should be eligible to the TC (with the possibility of exemptions).

### Alternate Designs
None.

### Possible Drawbacks
None. There's an exemption process we can use if necessary.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
