### PR TITLE
Update TC members after elections

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -238,9 +238,8 @@ Members of the Technical Committee are the individuals listed below. You can rea
 
 Full Name         | Company              | GitHub                                                        | Elected On | Until
 ------------------|:--------------------:|---------------------------------------------------------------|------------|-----------
-Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | May 2024   | May 2025
-Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | May 2024   | May 2025
-Mattias Linnér    | Ericsson             | [m-linner-ericsson](https://github.com/m-linner-ericsson)     | May 2024   | May 2025
+Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | May 2025   | May 2026
+Mattias Linnér    | Ericsson             | [m-linner-ericsson](https://github.com/m-linner-ericsson)     | May 2025   | May 2026
 
 The technical committee members will strive to
 
@@ -258,12 +257,7 @@ The committee elects two Technical Committee Chairs from within members, who wil
 
 The goal of this position is servant leadership for the Eiffel Community, projects that take part in Eiffel Community, committee and stakeholders.
 
-Current Technical Committee chairs are:
-
-Full Name         | Company              | GitHub                                                        | Elected On | Until
-------------------|:--------------------:|---------------------------------------------------------------|------------|-----------
-Emil Bäckmark     | Ericsson             | [e-backmark-ericsson](https://github.com/e-backmark-ericsson) | May 2024   | May 2025
-Magnus Bäck       | Axis Communications  | [magnusbaeck](https://github.com/magnusbaeck)                 | May 2024   | May 2025
+As the Technical Committee currently only has two members, no chairs have been elected.
 
 The chairs MUST ensure that
 

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -10,9 +10,9 @@ contribute by adding the resource to this file through a Pull Request.
 |------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | [GitHub](https://github.com/eiffel-community)                                      | [TC](https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee-members) |
 | [Slack](https://eiffel-workspace.slack.com/)                                       | [Magnus Bäck](https://github.com/magnusbaeck)                                                             |
-| [YouTube](https://www.youtube.com/@EiffelCommunity)                                | [Emil Bäckmark](https://github.com/e-backmark-ericsson)                                                   |
+| [YouTube](https://www.youtube.com/@EiffelCommunity)                                | [Mattias Linnér](https://github.com/m-linner-ericsson)                                                    |
 | [LinkedIn](https://www.linkedin.com/company/40197226)                              | [TC](https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee-members) |
-| [HackMD](https://hackmd.io/team/eiffel-community?nav=overview)                     | [Emil Bäckmark](https://github.com/e-backmark-ericsson)                                                   |
+| [HackMD](https://hackmd.io/team/eiffel-community?nav=overview)                     | [Magnus Bäck](https://github.com/magnusbaeck)                                                             |
 | [Travis CI](https://app.travis-ci.com/organizations/eiffel-community/repositories) | [TC](https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee-members) |
 | [Codacy](https://app.codacy.com/)                                                  | ?                                                                                                         |
 | [Reviewable](https://reviewable.io/)                                               | ?                                                                                                         |


### PR DESCRIPTION
### Applicable Issues
N/A; executing [post-election checklist](https://github.com/eiffel-community/community/blob/master/howtos/post-tc-election-checklist.md)

### Description of the Change
After the 2025 TC elections, remove @e-backmark-ericsson from the TC and clear out the TC chairs as none will be elected this year.

### Alternate Designs
None.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
