### PR TITLE
Remove Travis CI from RESOURCES.md

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -13,7 +13,6 @@ contribute by adding the resource to this file through a Pull Request.
 | [YouTube](https://www.youtube.com/@EiffelCommunity)                                | [Mattias Linnér](https://github.com/m-linner-ericsson)                                                    |
 | [LinkedIn](https://www.linkedin.com/company/40197226)                              | [TC](https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee-members) |
 | [HackMD](https://hackmd.io/team/eiffel-community?nav=overview)                     | [Magnus Bäck](https://github.com/magnusbaeck)                                                             |
-| [Travis CI](https://app.travis-ci.com/organizations/eiffel-community/repositories) | [TC](https://github.com/eiffel-community/community/blob/master/GOVERNANCE.md#technical-committee-members) |
 | [Codacy](https://app.codacy.com/)                                                  | ?                                                                                                         |
 | [Reviewable](https://reviewable.io/)                                               | ?                                                                                                         |
 


### PR DESCRIPTION
### Description

Remove the Travis CI entry from RESOURCES.md. Travis CI has not been used in this organization for over 4 years.

Part of #227 (Close down our Travis account).

### Motivation

Travis CI is no longer used. The organization is closing down its Travis account.

### Exemplification

N/A

### Benefits

Removes stale reference to an unused service.

### Possible Drawbacks

None.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Mattias Linnér <mattias.linner@ericsson.com>